### PR TITLE
Adding command line option to exclude packages and classes.

### DIFF
--- a/kraal/src/main/kotlin/com/hpe/kraal/FileHandler.kt
+++ b/kraal/src/main/kotlin/com/hpe/kraal/FileHandler.kt
@@ -49,7 +49,10 @@ fun removeIrreducibleLoops(classNode: ClassNode): Boolean {
  * If the class has related types (e.g. supertypes) that cannot be loaded by the current thread's context classloader,
  * then a [classloader] that can must be specified.
  */
-fun removeIrreducibleLoops(file: Path, classloader: ClassLoader = Thread.currentThread().contextClassLoader): Boolean {
+fun removeIrreducibleLoops(
+    file: Path,
+    classloader: ClassLoader = Thread.currentThread().contextClassLoader,
+    excludeList: ArrayList<String> = arrayListOf<String>()): Boolean {
     if (file.toString().endsWith(".class")) {
         return processClassFile(file, classloader)
     } else if (file.toString().endsWith(".jar")) {
@@ -59,9 +62,11 @@ fun removeIrreducibleLoops(file: Path, classloader: ClassLoader = Thread.current
             val classes = Files.walk(zipfs.getPath("/")).filter { entry ->
                 entry.toString().endsWith(".class") && !Files.isDirectory(entry)
             }
-
+            val mClasses = classes.filter { className ->
+                excludeList.filter { pattern -> className.toString().contains(pattern) }.isEmpty()
+            }
             var modified = false
-            for (classFile in classes) {
+            for (classFile in mClasses) {
                 modified = processClassFile(classFile, classloader) || modified
             }
             return modified


### PR DESCRIPTION
Introducing 2 command line options to exclude packages and class. Kraal
will skip files that matches exclusion list, a comma separated list of
packages and classes.

--excludePackages="org.pkg1,org.pkg2"
--excludeClasses="class1,class2"

Signed-off-by: Chintana Wilamuna <chintana@wso2.com>